### PR TITLE
feat: typescript 3 -> 4

### DIFF
--- a/_templates/plugin/new/package.json.t
+++ b/_templates/plugin/new/package.json.t
@@ -41,7 +41,7 @@ to: packages/plugin-<%= name %>/package.json
     "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
   },

--- a/_templates/sdk/new/package.json.t
+++ b/_templates/sdk/new/package.json.t
@@ -29,7 +29,7 @@ to: packages/sdk-<%= name %>/package.json
   "author": "<%= author %>",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "<%= itlySdkModule %>": "<%= itlySdkVersion %>"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.0",
     "ts-node": "^9.1.1",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "husky": {
     "hooks": {

--- a/packages/plugin-amplitude-node/package.json
+++ b/packages/plugin-amplitude-node/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "@amplitude/identify": "^1.5.5",

--- a/packages/plugin-amplitude-react-native/package.json
+++ b/packages/plugin-amplitude-react-native/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@amplitude/react-native": "^2.3.1",
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@amplitude/react-native": "^2.3.1",

--- a/packages/plugin-amplitude/package.json
+++ b/packages/plugin-amplitude/package.json
@@ -38,7 +38,7 @@
     "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-braze-node/package.json
+++ b/packages/plugin-braze-node/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
     "@types/node-fetch": "^2.5.8",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "node-fetch": "^2.6.1"

--- a/packages/plugin-braze/package.json
+++ b/packages/plugin-braze/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "@braze/web-sdk-core": "^3.2.0"

--- a/packages/plugin-firebase-react-native/package.json
+++ b/packages/plugin-firebase-react-native/package.json
@@ -37,7 +37,7 @@
     "@itly/sdk": "^2.3.4",
     "@react-native-firebase/analytics": "^10.8.1",
     "@react-native-firebase/app": "^10.8.1",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0",

--- a/packages/plugin-google-analytics/package.json
+++ b/packages/plugin-google-analytics/package.json
@@ -39,7 +39,7 @@
     "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-iteratively-node/package.json
+++ b/packages/plugin-iteratively-node/package.json
@@ -44,7 +44,7 @@
     "@types/uuid": "^8.3.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-iteratively/package.json
+++ b/packages/plugin-iteratively/package.json
@@ -42,7 +42,7 @@
     "@types/uuid": "^8.3.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-mixpanel-node/package.json
+++ b/packages/plugin-mixpanel-node/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "mixpanel": "^0.13.0"

--- a/packages/plugin-mixpanel/package.json
+++ b/packages/plugin-mixpanel/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-mparticle-react-native/package.json
+++ b/packages/plugin-mparticle-react-native/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
     "react-native-mparticle": "^2.4.9",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0",

--- a/packages/plugin-mparticle/package.json
+++ b/packages/plugin-mparticle/package.json
@@ -38,7 +38,7 @@
     "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-schema-validator/package.json
+++ b/packages/plugin-schema-validator/package.json
@@ -38,7 +38,7 @@
     "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "jsonschema": "^1.4.0",

--- a/packages/plugin-segment-node/package.json
+++ b/packages/plugin-segment-node/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "@types/analytics-node": "^3.1.4",

--- a/packages/plugin-segment-react-native/package.json
+++ b/packages/plugin-segment-react-native/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
     "@segment/analytics-react-native": "^1.4.3",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0",

--- a/packages/plugin-segment/package.json
+++ b/packages/plugin-segment/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-snowplow-react-native/package.json
+++ b/packages/plugin-snowplow-react-native/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
     "@snowplow/react-native-tracker": "^0.1.3",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0",

--- a/packages/plugin-snowplow/package.json
+++ b/packages/plugin-snowplow/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@itly/sdk": "^2.3.4",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/plugin-testing/package.json
+++ b/packages/plugin-testing/package.json
@@ -38,7 +38,7 @@
     "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "peerDependencies": {
     "@itly/sdk": "^2.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
     "jest": "^26.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.0",
-    "typescript": "^3.9.3"
+    "typescript": "^4.3.5"
   },
   "gitHead": "6694fa97c4d96177674b6acc491b19c3013387c3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8437,10 +8437,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.3:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 uglify-js@^3.1.4:
   version "3.13.10"


### PR DESCRIPTION
Move from compiling on typescript 3.9 to typescript 4.3.

This is annoying me as it means we end up with a production dependency of 3.9, instead of the 4.3 we're using locally. I have no idea how this is ending up as a production dependency, but it is! Thanks yarn. Tharn.

Note that typescript aren't great at semver; 3.8 -> 3.9 is the same level as change as 3.9 -> 4.0 and 4.1 -> 4.2, etc.

That is, this isn't a huge breaking change.